### PR TITLE
added custom error handling to avoid crash in initialization of AXCGiphy

### DIFF
--- a/Giphy-iOS.podspec
+++ b/Giphy-iOS.podspec
@@ -7,7 +7,7 @@ Pod::Spec.new do |s|
   s.homepage         = "https://github.com/heyalexchoi/Giphy-iOS"
   s.license          = 'MIT'
   s.author           = { "Alex Choi" => "heyalexchoi@gmail.com" }
-  s.source           = { :git => "git@github.com:heyalexchoi/Giphy-iOS.git", :tag => s.version.to_s }
+  s.source           = { :git => "https://github.com/heyalexchoi/Giphy-iOS.git", :tag => s.version.to_s }
 
   s.platform     = :ios, '7.0'
   s.requires_arc = true

--- a/Pod/Classes/AXCGiphy.m
+++ b/Pod/Classes/AXCGiphy.m
@@ -144,6 +144,7 @@ static NSString * kGiphyAPIKey;
             // json serialize error
             NSError * error;
             NSDictionary * results = [NSJSONSerialization JSONObjectWithData:data options:NSJSONReadingAllowFragments error:&error];
+            error = error ?: [self customErrorFromResults:results];
             if (error) {
                 block(nil, error);
             } else {
@@ -168,6 +169,7 @@ static NSString * kGiphyAPIKey;
             // json serialize error
             NSError * error;
             NSDictionary * results = [NSJSONSerialization JSONObjectWithData:data options:NSJSONReadingAllowFragments error:&error];
+            error = error ?: [self customErrorFromResults:results];
             if (error) {
                 block(nil, error);
             } else {
@@ -192,6 +194,7 @@ static NSString * kGiphyAPIKey;
             // json serialize error
             NSError * error;
             NSDictionary * results = [NSJSONSerialization JSONObjectWithData:data options:NSJSONReadingAllowFragments error:&error];
+            error = error ?: [self customErrorFromResults:results];
             if (error) {
                 block(nil, error);
             } else {
@@ -217,6 +220,7 @@ static NSString * kGiphyAPIKey;
             // json serialize error
             NSError * error;
             NSDictionary * results = [NSJSONSerialization JSONObjectWithData:data options:NSJSONReadingAllowFragments error:&error];
+            error = error ?: [self customErrorFromResults:results];
             if (error) {
                 block(nil, error);
             } else {
@@ -241,6 +245,7 @@ static NSString * kGiphyAPIKey;
             // json serialize error
             NSError * error;
             NSDictionary * results = [NSJSONSerialization JSONObjectWithData:data options:NSJSONReadingAllowFragments error:&error];
+            error = error ?: [self customErrorFromResults:results];
             if (error) {
                 block(nil, error);
             } else {
@@ -252,4 +257,15 @@ static NSString * kGiphyAPIKey;
     [task resume];
     return task;
 }
+
++ (NSError *)customErrorFromResults:(NSDictionary *)results
+{
+    NSArray * resultsData = results[@"data"];
+    if ([resultsData count] == 0) {
+        return [[NSError alloc] initWithDomain:@"com.giphy.ios" code:-1 userInfo:@{@"error_message" : @"No results were found"}];
+    }
+    return nil;
+}
+
+
 @end


### PR DESCRIPTION
This avoids a crash when the results set is empty and `results[@"data"]` is an empty array
